### PR TITLE
Containerfile: Install osbuild from COPR to pull a fix for the loop bug

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,6 +4,11 @@ COPY build.sh .
 RUN ./build.sh
 
 FROM registry.fedoraproject.org/fedora:39
+# Install newer osbuild to fix the loop bug, see
+# - https://github.com/osbuild/osbuild-deploy-container/issues/7
+# - https://github.com/osbuild/osbuild-deploy-container/issues/9
+# - https://github.com/osbuild/osbuild/pull/1468
+COPY ./group_osbuild-osbuild-fedora-39.repo /etc/yum.repos.d/
 RUN dnf install -y osbuild osbuild-ostree && dnf clean all
 COPY --from=builder images/osbuild-deploy-container /usr/bin/osbuild-deploy-container
 COPY entrypoint.sh /

--- a/group_osbuild-osbuild-fedora-39.repo
+++ b/group_osbuild-osbuild-fedora-39.repo
@@ -1,0 +1,10 @@
+[copr:copr.fedorainfracloud.org:group_osbuild:osbuild]
+name=Copr repo for osbuild owned by @osbuild
+baseurl=https://download.copr.fedorainfracloud.org/results/@osbuild/osbuild/fedora-$releasever-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/@osbuild/osbuild/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
Builds are failing on certain systems on:
```
AttributeError: 'Loop' object has no attribute 'fd'
osbuild.host.RemoteError: FileNotFoundError: [Errno 2] No such file or directory: 'loop1'
```

This happens because /dev in a container is a statically created tmpfs. Thus, when a new loop device is allocated, it doesn't appear in the container. A newer version of osbuild fixes that by always making sure that the loop device exists (by simply calling `mknod`).

Pull the fix from COPR to unblock us, instead of waiting for the fix to flow into stable Fedora.

`dnf copr enable` requires `dnf-plugins-core` that's not installed by default. Let's just use a static .repo file instead, it feels a tad bit simpler.

Fixes #7 
Fixes #9