### PR TITLE
prepare.sh: label osbuild,setfiles "correctly" in the container

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -3,8 +3,7 @@
 set -euo pipefail
 
 # Create a new tmpfs. This solves two issues for us:
-# - / is mounted as nosuid, this prevents SELinux to transition to `install_t` because domain transitions are
-#   disallowed if they give more caps to the process and the target executable is on `nosuid` filesystem
+# - / can be mounted as overlayfs with all files being `system_u:object_r:container_files_t`
 # - / can be mounted as OverlayFS that doesn't support overlaying SELinux labels. Thus, we need to ensure that
 #  the relabeling happens on a mountpoint that's definitely not an OverlayFS.
 TMP=/run/suidtmp
@@ -16,15 +15,16 @@ mount -t tmpfs tmpfs "${TMP}"
 
 # Copy osbuild to the new mountpoint.
 cp /usr/bin/osbuild "${TMP}/osbuild"
+# Also copy setfiles
+cp /usr/sbin/setfiles "${TMP}/setfiles"
 
-# Label it as `install_exec_t`. We need this in order to get `install_t` that has `CAP_MAC_ADMIN` for creating SELinux
-# labels unknown to the host.
-#
-# Note that the transition to `install_t` must happen at this point. Osbuild stages run in `bwrap` that creates
-# a nosuid, no_new_privs environment. In such an environment, we cannot transition from `unconfined_t` to `install_t`,
-# because we would get more privileges.
-chcon system_u:object_r:install_exec_t:s0 "${TMP}/osbuild"
+# All labels inside the container are "wrong" but the only two we care
+# about are "osbuild" and "setfiles" so label them "correctly" (as
+# they are labeled on a real system).
+chcon system_u:object_r:osbuild_exec_t:s0 "${TMP}/osbuild"
+chcon system_u:object_r:setfiles_exec_t:s0 "${TMP}/setfiles"
 
 # "Copy" back the relabeled osbuild to its right place. We obviously cannot copy it, so let's bind-mount it instead.
 # Once again, we don't care about clean-up, this is MS_SHARED.
 mount -o bind "${TMP}/osbuild" /usr/bin/osbuild
+mount -o bind "${TMP}/setfiles" /usr/bin/setfiles


### PR DESCRIPTION
When running osbuild inside a container the selinux setup is slightly different from a non container setup:

Inside the container all files under "/" in the overlayfs have the label `system_u:object_r:container_files_t`. This includes `/usr/bin/osbuild` and `/usr/sbin/setfiles`. Because the container is using an overlayfs the files cannot directly relabled under "/" with the correct selinux labels. This is why `prepare.sh` creates a tmpfs and relabels there and bind mounts back.

This commit tweaks this mechanism now to create labels that are closer to a real selinux system. I.e. it will:
1. label /usr/bin/osbuild as `osbuild_exec_t`
2. label /usr/sbin/setfiles as `setfiles_exec_t`

With that the normal transition rules work, i.e. osbuild_exec_t can transition to mount_t and when setfiles is called it will automatically use `setfiles_exec_t`.

With this PR I do not see any selinux denials when running the container anymore. I want to do a regression test for this as well to ensure that we don't regress and that this can be easily tested on multiple versions of fedora/rhel but that will have to be a followup as it's a bit of work.

Fwiw, AFAICT the root mount is not actually mounted "nosuid" (at last on my fc38 test system), I think the denials are from the fact that setfiles was not labeled correctly before.

[edit: setting to draft until some knowledgeable people had the chance to look at this first :)]
[edit2: an alternative would be to label {,u}mount inside the buildroot only, https://github.com/osbuild/images/compare/main...mvo5:bifrost/build-root-install_t-labeling?expand=1 - but this version here seem cleaner to me]